### PR TITLE
Remove round recap score line

### DIFF
--- a/src/components/ArenaBrawl.tsx
+++ b/src/components/ArenaBrawl.tsx
@@ -861,7 +861,6 @@ const ArenaBrawl: React.FC = () => {
                 <div className={`space-y-2 mb-6 ${isMobile ? 'text-base' : 'text-lg'}`}>
                   <div>Round {gameSession.currentRound} of {gameSession.totalRounds}</div>
                   <div>Place: <span className="text-primary font-bold">#{gameResult.place}</span></div>
-                  <div>Score: <span className="text-neon-cyan font-bold">{gameResult.score}</span></div>
                   <div className="text-xl font-bold text-neon-yellow mt-4">
                     Total Score: {gameSession.cumulativeScore}
                   </div>


### PR DESCRIPTION
## Summary
- remove the per-round `score` line from the round-end overlay

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6886187fedf88333a2f81687080994af