### PR TITLE
Scale enemy stats with round

### DIFF
--- a/src/components/ArenaBrawl.tsx
+++ b/src/components/ArenaBrawl.tsx
@@ -458,7 +458,8 @@ const ArenaBrawl: React.FC = () => {
   const handleShopContinue = () => {
     if (gameSession.playerCharacter && gameSession.enemyCharacters) {
       // Upgrade all enemy characters with random stats
-      const upgradedEnemies = gameSession.enemyCharacters.map(enemy => upgradeEnemyCharacter(enemy));
+      const nextRound = gameSession.currentRound + 1;
+      const upgradedEnemies = gameSession.enemyCharacters.map(enemy => upgradeEnemyCharacter(enemy, nextRound));
       
       setGameSession(prev => ({ 
         ...prev, 

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -251,7 +251,7 @@ export function isInAttackAOE(targetPos: Vec2, attackerPos: Vec2, attackDirectio
   }
 }
 
-export function upgradeEnemyCharacter(character: Character): Character {
+export function upgradeEnemyCharacter(character: Character, round: number = 1): Character {
   const upgradedCharacter = { ...character };
   
   // Initialize base stats if not present
@@ -271,13 +271,17 @@ export function upgradeEnemyCharacter(character: Character): Character {
     attackPower: Math.floor(Math.random() * 4), // 0-3
     speed: Math.floor(Math.random() * 4) // 0-3
   };
+
+  // Scaling factor makes later rounds 10-30% stronger than the previous
+  const roundsAhead = Math.max(round - (upgradedCharacter.level ?? 1), 1);
+  const scalingFactor = 1 + (0.1 + Math.random() * 0.2) * roundsAhead;
   
-  // Apply random upgrades
+  // Apply random upgrades and round-based scaling
   upgradedCharacter.stats = {
     ...upgradedCharacter.stats,
-    hp: upgradedCharacter.stats.hp + statUpgrades.hp,
+    hp: Math.round((upgradedCharacter.stats.hp + statUpgrades.hp) * scalingFactor),
     defense: upgradedCharacter.stats.defense + statUpgrades.defense,
-    attackPower: upgradedCharacter.stats.attackPower + statUpgrades.attackPower,
+    attackPower: Math.round((upgradedCharacter.stats.attackPower + statUpgrades.attackPower) * scalingFactor),
     speed: upgradedCharacter.stats.speed + statUpgrades.speed
   };
   


### PR DESCRIPTION
## Summary
- scale enemy HP and attack by 10-30% between rounds
- call upgradeEnemyCharacter with the next round number

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688618c20fa483338637866785af7d46